### PR TITLE
feat: add Router custom options symbol and refactor route options structure

### DIFF
--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -3,6 +3,8 @@ import { type Decorator, type Descriptor, decorate } from "@jondotsoy/decorate";
 import { errorToResponse } from "../utils/describeErrorResponse.js";
 import type { IncomingMessage } from "http";
 
+const customOptionsSymbol = Symbol("Router.customOptions");
+
 type HTTPMethods =
   | "GET"
   | "POST"
@@ -47,15 +49,18 @@ export type FetchDescriptor<T> = Descriptor<
 
 export type Middleware<T> = Decorator<FetchDescriptor<T>>;
 
+export type RouterOptionsDef<T> = {
+  /** The test function */
+  test?: (request: Request) => Promise<boolean> | boolean;
+  middlewares?: Middleware<T>[];
+  fetch?: (request: RequestWithParams<T>) => FetcherResponse;
+  [customOptionsSymbol]?: Partial<RouterOptionsDef<T>>;
+};
+
 export type Route<T> = {
   method: "ALL" | HTTPMethods;
   urlPattern: URLPattern;
-  options?: {
-    /** The test function */
-    test?: (request: Request) => Promise<boolean> | boolean;
-    middlewares?: Middleware<T>[];
-    fetch?: (request: RequestWithParams<T>) => FetcherResponse;
-  };
+  options?: RouterOptionsDef<T>;
 };
 
 export const defaultCatching = (ex: unknown) => {
@@ -99,6 +104,8 @@ const urlPatternFrom = (value: unknown): URLPattern => {
 };
 
 export class Router<E extends ErrorHandling = "default-catching"> {
+  static customOptions = customOptionsSymbol;
+
   routes: Route<any>[] = [];
 
   options: RouterOptions<E>;
@@ -118,7 +125,10 @@ export class Router<E extends ErrorHandling = "default-catching"> {
     this.routes.push({
       method,
       urlPattern: urlPatternFrom(urlPatternOrPathPattern),
-      options,
+      options:
+        options && customOptionsSymbol in options
+          ? options[customOptionsSymbol]
+          : options,
     });
 
     return this;


### PR DESCRIPTION
## Changes

This PR introduces improvements to the Router class to support custom options and better type organization:

### ✨ Features
- **Custom Options Symbol**: Added `Router.customOptions` static property that provides a symbol for accessing custom router options
- **Named Router Options Type**: Extracted inline route options into a reusable `RouterOptionsDef<T>` type for better maintainability

### 🔧 Technical Details
- Created `customOptionsSymbol` constant for type-safe custom options access
- Refactored anonymous options object type into named `RouterOptionsDef<T>` interface
- Added logic in route registration to handle custom options through the symbol property
- Maintains backward compatibility with existing route options structure

### 🧪 Testing
- ✅ All existing tests pass (26 tests across 2 files)
- No breaking changes to the public API

### 📝 Type Safety
The new structure maintains full type safety while allowing for extensible custom options through the symbol property pattern, providing a clean way to extend router functionality without polluting the main options interface.

**Files Changed:**
- `src/http/router.ts` (+17 lines, -7 lines)