### PR TITLE
build: enhance npm publishing security with provenance attestation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
 name: Release
 
 permissions:
+  id-token: write
   contents: write
   pull-requests: write
 
@@ -32,6 +33,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - uses: oven-sh/setup-bun@v1
       - run: bun i
-      - run: npm publish
+      - run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

This PR enhances the security and transparency of npm package publishing by adding provenance attestation to the release workflow. This enables package consumers to verify the authenticity and integrity of published packages.

## Changes Made

- **Added `id-token: write` permission**: Required for GitHub Actions to generate OIDC tokens for provenance attestation
- **Updated npm publish command**: Added `--provenance` flag to enable automatic provenance generation during publishing
- **Enhanced supply chain security**: Packages will now include cryptographic proof of their build provenance

## What is Provenance?

Provenance attestation provides:
- **Build transparency**: Cryptographic proof of where and how the package was built
- **Supply chain security**: Protection against tampering and unauthorized modifications  
- **Audit trail**: Verifiable link between source code and published package
- **Trust verification**: Consumers can verify the package came from the expected source

## Benefits

- 🔒 **Enhanced Security**: Protects against supply chain attacks
- 🔍 **Transparency**: Users can verify package authenticity
- ✅ **Compliance**: Meets modern security best practices for package distribution
- 🛡️ **Trust**: Builds confidence in package integrity

## Technical Details

The `--provenance` flag works with GitHub Actions to:
1. Generate an OIDC token using the `id-token: write` permission
2. Create a cryptographic attestation linking the package to its source
3. Publish the attestation alongside the package to npm
4. Enable verification via `npm audit signatures`

## Testing

- ✅ All existing tests pass (`bun test`)
- ✅ Workflow changes only, no application code modifications  
- ✅ 2 lines added, 1 line modified, 1 file changed

This enhancement aligns with npm's security recommendations and provides users with greater confidence in package authenticity without any breaking changes to the existing functionality.