### PR TITLE
refactor: standardize URLPattern imports from urlpattern-polyfill

### DIFF
--- a/src/http/types/route.ts
+++ b/src/http/types/route.ts
@@ -1,4 +1,4 @@
-import type { URLPattern } from "urlpattern-polyfill/urlpattern";
+import type { URLPattern } from "urlpattern-polyfill";
 import type { RouterOptionsDef } from "./router-options-def.js";
 import type { HTTPMethods } from "./http-methods-types.js";
 import type { Fetch } from "./fetch-type.js";

--- a/src/http/utils/url-pattern-from.ts
+++ b/src/http/utils/url-pattern-from.ts
@@ -1,4 +1,4 @@
-import { URLPattern } from "urlpattern-polyfill/urlpattern";
+import { URLPattern } from "urlpattern-polyfill";
 
 /**
  * Converts a given value to a `URLPattern` instance.

--- a/src/http/utils/use-argument-parser.spec.ts
+++ b/src/http/utils/use-argument-parser.spec.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import { describe, expect, test } from "bun:test";
 import { useArgumentParser, parseUseArguments } from "./use-argument-parser";
-import { URLPattern } from "urlpattern-polyfill/urlpattern";
+import { URLPattern } from "urlpattern-polyfill";
 import type { Route } from "../types/route";
 import { urlPatternFrom } from "./url-pattern-from";
 import { ArgumentsError } from "../errors/arguments-error";

--- a/src/http/utils/use-argument-parser.ts
+++ b/src/http/utils/use-argument-parser.ts
@@ -1,4 +1,4 @@
-import { URLPattern } from "urlpattern-polyfill/urlpattern";
+import { URLPattern } from "urlpattern-polyfill";
 import { urlPatternFrom } from "./url-pattern-from.js";
 import type { Fetch } from "../types/fetch-type.js";
 import { ArgumentsError } from "../errors/arguments-error.js";


### PR DESCRIPTION
## Changes

This PR standardizes URLPattern imports across the codebase by updating import paths from `"urlpattern-polyfill/urlpattern"` to `"urlpattern-polyfill"`.

### Files Modified
- `src/http/types/route.ts` - Updated type import
- `src/http/utils/url-pattern-from.ts` - Updated runtime import  
- `src/http/utils/use-argument-parser.ts` - Updated runtime import
- `src/http/utils/use-argument-parser.spec.ts` - Updated test import

### Testing
✅ All tests pass (86 pass, 2 skip, 0 fail)

### Impact
- **Breaking Change**: Updates import paths for URLPattern polyfill
- **Consistency**: All files now use the same import path format
- **Compatibility**: Maintains functionality while using the standard import pattern

This change ensures consistency across the codebase and follows the recommended import pattern for the urlpattern-polyfill package.