### PR TITLE
feat: implement OpenRPC document generation with enhanced validation types

### DIFF
--- a/src/json-rpc/json-rpc-router.spec.ts
+++ b/src/json-rpc/json-rpc-router.spec.ts
@@ -466,19 +466,8 @@ describe("JsonRpcRouter", () => {
       id: 1,
       jsonrpc: "2.0",
       result: {
-        methods: [
-          {
-            name: "testMethod",
-            params: {
-              type: "object",
-              properties: {
-                name: { type: "string" },
-              },
-              required: ["name"],
-              additionalProperties: false,
-            },
-          },
-        ],
+        info: {},
+        methods: [{ name: "testMethod" }],
       },
     });
   });
@@ -504,25 +493,10 @@ describe("JsonRpcRouter", () => {
       id: 1,
       jsonrpc: "2.0",
       result: {
+        info: {},
         methods: [
           {
             name: "testMethod",
-            params: {
-              type: "object",
-              properties: {
-                name: { type: "string" },
-              },
-              required: ["name"],
-              additionalProperties: false,
-            },
-            result: {
-              type: "object",
-              properties: {
-                ok: { type: "boolean" },
-              },
-              required: ["ok"],
-              additionalProperties: false,
-            },
           },
         ],
       },

--- a/src/json-rpc/json-rpc-router.ts
+++ b/src/json-rpc/json-rpc-router.ts
@@ -45,7 +45,7 @@ export class JsonRpcRouter {
   >();
 
   /** Configuration options for the router */
-  private options: JsonRpcRouterOptions;
+  readonly options: JsonRpcRouterOptions;
 
   /**
    * Creates a new JSON-RPC router.
@@ -531,4 +531,17 @@ export class JsonRpcRouter {
     method: "ALL",
     fetch: this.fetch,
   });
+
+  static *getMethods(jsonRpcRouter: JsonRpcRouter) {
+    for (const method of jsonRpcRouter.handlers.keys()) {
+      const methodKey = method;
+      const validations = jsonRpcRouter.paramsValidations.get(method);
+
+      yield {
+        method: methodKey,
+        params: validations?.input,
+        result: validations?.output,
+      };
+    }
+  }
 }

--- a/src/json-rpc/json-rpc-router.ts
+++ b/src/json-rpc/json-rpc-router.ts
@@ -1,5 +1,5 @@
 import type { ExtractValidationType } from "./types/extract-validation-type.js";
-import type { Validation } from "./types/validation.js";
+import type { ParamsValidation, Validation } from "./types/validation.js";
 import type { JsonRpcHandler } from "./types/json-rpc-handler.js";
 import type { JsonRpcEvent } from "./types/json-rpc-event.js";
 import type { JsonRpcResponse } from "./types/json-rpc-response.js";
@@ -41,7 +41,7 @@ export class JsonRpcRouter {
   /** Map of method names to their parameter validation schemas */
   private paramsValidations = new Map<
     string,
-    { input?: Validation<any>; output?: Validation<any> }
+    { input?: ParamsValidation<any>; output?: Validation<any> }
   >();
 
   /** Configuration options for the router */
@@ -142,7 +142,7 @@ export class JsonRpcRouter {
    * @see {@link enableMethodListing} - For registering introspection methods
    */
   method<
-    InputValidation extends Validation<any> = any,
+    InputValidation extends ParamsValidation<any> = any,
     OutputValidation extends Validation<any> = any,
   >(
     method: string,

--- a/src/json-rpc/json-rpc-router.ts
+++ b/src/json-rpc/json-rpc-router.ts
@@ -6,7 +6,6 @@ import type { JsonRpcResponse } from "./types/json-rpc-response.js";
 import type { JsonRpcRequest } from "./types/json-rpc-request.js";
 import type { JsonRpcNotification } from "./types/json-rpc-notification.js";
 import { JsonRpcError } from "./json-rpc-error.js";
-import { z, toJSONSchema } from "zod";
 import { Router } from "../http/router.js";
 import { Queue } from "@jondotsoy/utils-js/queue";
 import { bodyRequest } from "./schemas/body-request.js";
@@ -19,6 +18,7 @@ import {
   EventSource,
   EventsReadableStream,
 } from "../event-source/event-source.js";
+import { fromJsonRpcRouter } from "./utils/open-rpc-document.js";
 
 export type { JsonRpcErrorResponse } from "./types/json-rpc-error-response.js";
 export type { JsonRpcResultResponse } from "./types/json-rpc-result-response.js";
@@ -220,26 +220,7 @@ export class JsonRpcRouter {
     hiddenMethods: string[] = [methodNames],
   ) {
     this.method(methodNames, async () => {
-      const methods: { name: string; params: any; result: any }[] = [];
-      for (const name of this.handlers.keys()) {
-        if (hiddenMethods.includes(name)) continue;
-        const validations = this.paramsValidations.get(name);
-        const method = {
-          name,
-          params:
-            validations?.input && validations?.input instanceof z.ZodType
-              ? toJSONSchema(validations.input)
-              : {},
-          result:
-            validations?.output && validations?.output instanceof z.ZodType
-              ? toJSONSchema(validations.output)
-              : {},
-        };
-        methods.push(method);
-      }
-      return {
-        methods,
-      };
+      return fromJsonRpcRouter(this, { hiddenMethods });
     });
   }
 

--- a/src/json-rpc/json-rpc-router.ts
+++ b/src/json-rpc/json-rpc-router.ts
@@ -10,7 +10,7 @@ import { z, toJSONSchema } from "zod";
 import { Router } from "../http/router.js";
 import { Queue } from "@jondotsoy/utils-js/queue";
 import { bodyRequest } from "./schemas/body-request.js";
-import type { JsonRpcDispatcherOptions } from "./types/json-rpc-dispatcher-options.js";
+import type { JsonRpcRouterOptions } from "./types/json-rpc-router-options.js";
 import { defaultExtractSessionId } from "./default-extract-session-id.js";
 import { sessionMemoryStore } from "./create-session-memory-store.1.js";
 import { Session } from "./session.js";
@@ -27,7 +27,7 @@ export type { JsonRpcRequest } from "./types/json-rpc-request.js";
 export type { JsonRpcNotification } from "./types/json-rpc-notification.js";
 
 /**
- * Main JSON-RPC dispatcher class.
+ * Main JSON-RPC router class.
  * Handles JSON-RPC 2.0 requests, method registration, session management,
  * and optional Server-Sent Events (SSE) support for real-time communication.
  */
@@ -44,14 +44,14 @@ export class JsonRpcRouter {
     { input?: Validation<any>; output?: Validation<any> }
   >();
 
-  /** Configuration options for the dispatcher */
-  private options: JsonRpcDispatcherOptions;
+  /** Configuration options for the router */
+  private options: JsonRpcRouterOptions;
 
   /**
-   * Creates a new JSON-RPC dispatcher.
+   * Creates a new JSON-RPC router.
    * @param options - Optional configuration options
    */
-  constructor(options?: Partial<JsonRpcDispatcherOptions>) {
+  constructor(options?: Partial<JsonRpcRouterOptions>) {
     const extractSessionId =
       options?.extractSessionId ??
       options?.sessionIdFactory ??
@@ -72,7 +72,7 @@ export class JsonRpcRouter {
   }
 
   /**
-   * Stops the dispatcher and waits for all pending requests to complete.
+   * Stops the router and waits for all pending requests to complete.
    */
   async stop() {
     await Promise.allSettled(this.requests);
@@ -107,10 +107,10 @@ export class JsonRpcRouter {
    * @example
    * ```typescript
    * // Simple method without validation
-   * dispatcher.registerMethod('ping', async () => 'pong');
+   * router.registerMethod('ping', async () => 'pong');
    *
    * // Method with input validation
-   * dispatcher.registerMethod(
+   * router.registerMethod(
    *   'user.getById',
    *   async (params) => getUserById(params.id),
    *   {
@@ -119,7 +119,7 @@ export class JsonRpcRouter {
    * );
    *
    * // Method with both input and output validation
-   * dispatcher.registerMethod(
+   * router.registerMethod(
    *   'user.create',
    *   async (params) => createUser(params),
    *   {
@@ -201,10 +201,10 @@ export class JsonRpcRouter {
    * @example
    * ```typescript
    * // Register a listMethods endpoint
-   * dispatcher.registerListMethods('system.listMethods');
+   * router.registerListMethods('system.listMethods');
    *
    * // Register with custom hidden methods
-   * dispatcher.registerListMethods('system.listMethods', ['system.listMethods', 'internal.debug']);
+   * router.registerListMethods('system.listMethods', ['system.listMethods', 'internal.debug']);
    * ```
    *
    * @remarks

--- a/src/json-rpc/session.ts
+++ b/src/json-rpc/session.ts
@@ -17,7 +17,7 @@ export class Session {
   /**
    * Creates a new JSON-RPC session.
    * @param id - Unique session identifier
-   * @param jsonRpcRouter - The dispatcher instance to handle requests
+   * @param jsonRpcRouter - The router instance to handle requests
    * @param queue - Message queue for handling responses
    */
   constructor(id: string, jsonRpcRouter: JsonRpcRouter, queue: Queue) {

--- a/src/json-rpc/types/json-rpc-router-options.ts
+++ b/src/json-rpc/types/json-rpc-router-options.ts
@@ -14,4 +14,10 @@ export type JsonRpcRouterOptions = {
   extractSessionId: (
     event: JsonRpcEvent,
   ) => string | null | Promise<string | null>;
+
+  info?: {
+    title?: string;
+    version?: string;
+    description?: string;
+  };
 };

--- a/src/json-rpc/types/json-rpc-router-options.ts
+++ b/src/json-rpc/types/json-rpc-router-options.ts
@@ -1,9 +1,9 @@
 import type { JsonRpcEvent } from "./json-rpc-event.js";
 
 /**
- * Configuration options for JsonRpcDispatcher.
+ * Configuration options for JsonRpcRouter.
  */
-export type JsonRpcDispatcherOptions = {
+export type JsonRpcRouterOptions = {
   /** Whether Server-Sent Events (SSE) support is enabled for real-time communication */
   sseEnabled: boolean;
   /** @deprecated Use {@link extractSessionId} instead. */

--- a/src/json-rpc/types/validation.ts
+++ b/src/json-rpc/types/validation.ts
@@ -1,3 +1,5 @@
-import type { ZodValidation } from "./zod-validation.js";
+import type { ParamsZodValidation, ZodValidation } from "./zod-validation.js";
 
 export type Validation<T> = ZodValidation<T>;
+
+export type ParamsValidation<T> = ParamsZodValidation<T>;

--- a/src/json-rpc/types/zod-validation.ts
+++ b/src/json-rpc/types/zod-validation.ts
@@ -9,7 +9,7 @@ export type ParamsZodValidation<T> =
   T extends Record<string, any>
     ? z.ZodObject<T>
     : T extends any[]
-      ? z.ZodArray<z.ZodType<T[number]>>
+      ? z.ZodTuple<T>
       : never;
 // z.ZodObject | z.ZodArray;
 // {

--- a/src/json-rpc/types/zod-validation.ts
+++ b/src/json-rpc/types/zod-validation.ts
@@ -1,3 +1,17 @@
-export type ZodValidation<T> = {
-  safeParse: (data: any) => { success: boolean; data?: T; error?: any };
-};
+import type { z } from "zod";
+
+export type ZodValidation<T> = z.ZodType<T>;
+// {
+//   safeParse: (data: any) => { success: boolean; data?: T; error?: any };
+// };
+
+export type ParamsZodValidation<T> =
+  T extends Record<string, any>
+    ? z.ZodObject<T>
+    : T extends any[]
+      ? z.ZodArray<z.ZodType<T[number]>>
+      : never;
+// z.ZodObject | z.ZodArray;
+// {
+//   safeParse: (data: any) => { success: boolean; data?: T; error?: any };
+// };

--- a/src/json-rpc/utils/__snapshots__/open-rpc-document.spec.ts.snap
+++ b/src/json-rpc/utils/__snapshots__/open-rpc-document.spec.ts.snap
@@ -1,0 +1,178 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`open-rpc-document should generate OpenRPC document for method with object parameters 1`] = `
+{
+  "info": {
+    "description": "A JSON-RPC service for various operations",
+    "title": "JSON-RPC Service",
+    "version": "1.0.0",
+  },
+  "methods": [
+    {
+      "name": "sum",
+      "params": [
+        {
+          "name": "a",
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "number",
+          },
+        },
+        {
+          "name": "b",
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "number",
+          },
+        },
+      ],
+      "result": {
+        "name": "result",
+        "schema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "number",
+        },
+      },
+    },
+  ],
+  "openrpc": "1.3.2",
+}
+`;
+
+exports[`open-rpc-document should generate OpenRPC document for method with tuple parameters 1`] = `
+{
+  "info": {
+    "description": "A JSON-RPC service for various operations",
+    "title": "JSON-RPC Service",
+    "version": "1.0.0",
+  },
+  "methods": [
+    {
+      "name": "sum",
+      "params": [
+        {
+          "name": "item0",
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "number",
+          },
+        },
+        {
+          "name": "item1",
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "number",
+          },
+        },
+      ],
+      "result": {
+        "name": "result",
+        "schema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "type": "number",
+        },
+      },
+    },
+  ],
+  "openrpc": "1.3.2",
+}
+`;
+
+exports[`open-rpc-document should generate OpenRPC document for method with object response 1`] = `
+{
+  "info": {
+    "description": "A JSON-RPC service for various operations",
+    "title": "JSON-RPC Service",
+    "version": "1.0.0",
+  },
+  "methods": [
+    {
+      "name": "sum",
+      "params": [
+        {
+          "name": "item0",
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "number",
+          },
+        },
+        {
+          "name": "item1",
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "number",
+          },
+        },
+      ],
+      "result": {
+        "name": "result",
+        "schema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "additionalProperties": false,
+          "properties": {
+            "result": {
+              "type": "number",
+            },
+          },
+          "required": [
+            "result",
+          ],
+          "type": "object",
+        },
+      },
+    },
+  ],
+  "openrpc": "1.3.2",
+}
+`;
+
+exports[`open-rpc-document should generate OpenRPC document for method with schema descriptions 1`] = `
+{
+  "info": {
+    "description": "A JSON-RPC service for various operations",
+    "title": "JSON-RPC Service",
+    "version": "1.0.0",
+  },
+  "methods": [
+    {
+      "name": "sum",
+      "params": [
+        {
+          "name": "item0",
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "description": "The first number",
+            "type": "number",
+          },
+        },
+        {
+          "name": "item1",
+          "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "description": "The second number",
+            "type": "number",
+          },
+        },
+      ],
+      "result": {
+        "name": "result",
+        "schema": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "additionalProperties": false,
+          "description": "The result of the sum",
+          "properties": {
+            "result": {
+              "type": "number",
+            },
+          },
+          "required": [
+            "result",
+          ],
+          "type": "object",
+        },
+      },
+    },
+  ],
+  "openrpc": "1.3.2",
+}
+`;

--- a/src/json-rpc/utils/open-rpc-document.spec.ts
+++ b/src/json-rpc/utils/open-rpc-document.spec.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect } from "bun:test";
+import { JsonRpcRouter } from "../json-rpc-router";
+import { z } from "zod";
+import { fromJsonRpcRouter } from "./open-rpc-document";
+
+describe("open-rpc-document", () => {
+  test("should generate OpenRPC document for method with object parameters", () => {
+    const router = new JsonRpcRouter();
+
+    router.method("sum", (params) => params.a + params.b, {
+      inputValidation: z.object({
+        a: z.number(),
+        b: z.number(),
+      }),
+      outputValidation: z.number(),
+    });
+
+    expect(fromJsonRpcRouter(router)).toMatchSnapshot();
+  });
+
+  test("should generate OpenRPC document for method with tuple parameters", () => {
+    const router = new JsonRpcRouter();
+
+    router.method("sum", ([a, b]) => a + b, {
+      inputValidation: z.tuple([z.number(), z.number()]),
+      outputValidation: z.number(),
+    });
+
+    expect(fromJsonRpcRouter(router)).toMatchSnapshot();
+  });
+
+  test("should generate OpenRPC document for method with object response", () => {
+    const router = new JsonRpcRouter();
+
+    router.method("sum", ([a, b]) => ({ result: a + b }), {
+      inputValidation: z.tuple([z.number(), z.number()]),
+      outputValidation: z.object({
+        result: z.number(),
+      }),
+    });
+
+    expect(fromJsonRpcRouter(router)).toMatchSnapshot();
+  });
+
+  test("should generate OpenRPC document for method with schema descriptions", () => {
+    const router = new JsonRpcRouter();
+
+    router.method("sum", ([a, b]) => ({ result: a + b }), {
+      inputValidation: z.tuple([z.number().describe("The first number"), z.number().describe("The second number")]),
+      outputValidation: z.object({
+        result: z.number(),
+      }).describe("The result of the sum"),
+    });
+
+    expect(fromJsonRpcRouter(router)).toMatchSnapshot();
+  });
+});

--- a/src/json-rpc/utils/open-rpc-document.spec.ts
+++ b/src/json-rpc/utils/open-rpc-document.spec.ts
@@ -46,10 +46,15 @@ describe("open-rpc-document", () => {
     const router = new JsonRpcRouter();
 
     router.method("sum", ([a, b]) => ({ result: a + b }), {
-      inputValidation: z.tuple([z.number().describe("The first number"), z.number().describe("The second number")]),
-      outputValidation: z.object({
-        result: z.number(),
-      }).describe("The result of the sum"),
+      inputValidation: z.tuple([
+        z.number().describe("The first number"),
+        z.number().describe("The second number"),
+      ]),
+      outputValidation: z
+        .object({
+          result: z.number(),
+        })
+        .describe("The result of the sum"),
     });
 
     expect(fromJsonRpcRouter(router)).toMatchSnapshot();

--- a/src/json-rpc/utils/open-rpc-document.ts
+++ b/src/json-rpc/utils/open-rpc-document.ts
@@ -413,7 +413,10 @@ export type OpenRPCVersion = `1.0.${number}`;
  */
 export const SERVICE_DISCOVERY_METHOD = "rpc.discover" as const;
 
-export const fromJsonRpcRouter = (jsonRpcRouter: JsonRpcRouter) => {
+export const fromJsonRpcRouter = (
+  jsonRpcRouter: JsonRpcRouter,
+  options?: { hiddenMethods?: string[] },
+) => {
   const document: OpenRPCDocument = {
     openrpc: "1.3.2",
     info: {
@@ -429,6 +432,9 @@ export const fromJsonRpcRouter = (jsonRpcRouter: JsonRpcRouter) => {
   for (const { method, params, result } of JsonRpcRouter.getMethods(
     jsonRpcRouter,
   )) {
+    const isHiddenMethod = options?.hiddenMethods?.includes(method);
+    if (isHiddenMethod) continue;
+
     const paramsO: (ContentDescriptorObject | ReferenceObject)[] = [];
     let resulO: undefined | ContentDescriptorObject | ReferenceObject =
       undefined;

--- a/src/json-rpc/utils/open-rpc-document.ts
+++ b/src/json-rpc/utils/open-rpc-document.ts
@@ -2,8 +2,8 @@
  * OpenRPC Specification v1.3.2 TypeScript Interfaces
  * Based on https://spec.open-rpc.org/
  */
-import { JsonRpcRouter } from "../json-rpc-router";
-import { z, toJSONSchema } from "zod";
+import { JsonRpcRouter } from "../json-rpc-router.js";
+import { toJSONSchema } from "zod";
 
 /**
  * Contact information for the exposed API.

--- a/src/json-rpc/utils/open-rpc-document.ts
+++ b/src/json-rpc/utils/open-rpc-document.ts
@@ -1,0 +1,470 @@
+/**
+ * OpenRPC Specification v1.3.2 TypeScript Interfaces
+ * Based on https://spec.open-rpc.org/
+ */
+import { JsonRpcRouter } from "../json-rpc-router";
+import { z, toJSONSchema } from "zod";
+
+/**
+ * Contact information for the exposed API.
+ */
+export interface ContactObject {
+  /** The identifying name of the contact person/organization. */
+  name?: string;
+  /** The URL pointing to the contact information. MUST be in the format of a URL. */
+  url?: string;
+  /** The email address of the contact person/organization. MUST be in the format of an email address. */
+  email?: string;
+  /** Specification extensions */
+  [pattern: `x-${string}`]: any;
+}
+
+/**
+ * License information for the exposed API.
+ */
+export interface LicenseObject {
+  /** REQUIRED. The license name used for the API. */
+  name: string;
+  /** A URL to the license used for the API. MUST be in the format of a URL. */
+  url?: string;
+  /** Specification extensions */
+  [pattern: `x-${string}`]: any;
+}
+
+/**
+ * The object provides metadata about the API.
+ */
+export interface InfoObject {
+  /** REQUIRED. The title of the application. */
+  title: string;
+  /** A verbose description of the application. GitHub Flavored Markdown syntax MAY be used for rich text representation. */
+  description?: string;
+  /** A URL to the Terms of Service for the API. MUST be in the format of a URL. */
+  termsOfService?: string;
+  /** The contact information for the exposed API. */
+  contact?: ContactObject;
+  /** The license information for the exposed API. */
+  license?: LicenseObject;
+  /** REQUIRED. The version of the OpenRPC document (which is distinct from the OpenRPC Specification version or the API implementation version). */
+  version: string;
+  /** Specification extensions */
+  [pattern: `x-${string}`]: any;
+}
+
+/**
+ * An object representing a Server Variable for server URL template substitution.
+ */
+export interface ServerVariableObject {
+  /** An enumeration of string values to be used if the substitution options are from a limited set. */
+  enum?: string[];
+  /** REQUIRED. The default value to use for substitution, which SHALL be sent if an alternate value is not supplied. */
+  default: string;
+  /** An optional description for the server variable. GitHub Flavored Markdown syntax MAY be used for rich text representation. */
+  description?: string;
+  /** Specification extensions */
+  [pattern: `x-${string}`]: any;
+}
+
+/**
+ * Runtime expression type for dynamic values
+ */
+export type RuntimeExpression = string;
+
+/**
+ * An object representing a Server.
+ */
+export interface ServerObject {
+  /** REQUIRED. A name to be used as the canonical name for the server. */
+  name: string;
+  /** REQUIRED. A URL to the target host. This URL supports Server Variables and MAY be relative. */
+  url: RuntimeExpression;
+  /** A short summary of what the server is. */
+  summary?: string;
+  /** An optional string describing the host designated by the URL. GitHub Flavored Markdown syntax MAY be used for rich text representation. */
+  description?: string;
+  /** A map between a variable name and its value. The value is passed into the Runtime Expression to produce a server URL. */
+  variables?: Record<string, ServerVariableObject>;
+  /** Specification extensions */
+  [pattern: `x-${string}`]: any;
+}
+
+/**
+ * Schema Object following JSON Schema Draft 7 specification.
+ * Can be used for defining input and output data types.
+ */
+export interface SchemaObject {
+  // Core schema properties (JSON Schema Draft 7)
+  $id?: string;
+  $schema?: string;
+  $ref?: string;
+  $comment?: string;
+
+  // Type definition
+  type?:
+    | "null"
+    | "boolean"
+    | "object"
+    | "array"
+    | "number"
+    | "string"
+    | "integer";
+  enum?: any[];
+  const?: any;
+
+  // Numeric constraints
+  multipleOf?: number;
+  maximum?: number;
+  exclusiveMaximum?: number;
+  minimum?: number;
+  exclusiveMinimum?: number;
+
+  // String constraints
+  maxLength?: number;
+  minLength?: number;
+  pattern?: string;
+
+  // Array constraints
+  items?: SchemaObject | SchemaObject[];
+  additionalItems?: SchemaObject;
+  maxItems?: number;
+  minItems?: number;
+  uniqueItems?: boolean;
+  contains?: SchemaObject;
+
+  // Object constraints
+  maxProperties?: number;
+  minProperties?: number;
+  required?: string[];
+  properties?: Record<string, SchemaObject>;
+  patternProperties?: Record<string, SchemaObject>;
+  additionalProperties?: boolean | SchemaObject;
+  dependencies?: Record<string, SchemaObject | string[]>;
+  propertyNames?: SchemaObject;
+
+  // Conditional
+  if?: SchemaObject;
+  then?: SchemaObject;
+  else?: SchemaObject;
+
+  // Logical
+  allOf?: SchemaObject[];
+  anyOf?: SchemaObject[];
+  oneOf?: SchemaObject[];
+  not?: SchemaObject;
+
+  // Meta-data
+  title?: string;
+  description?: string;
+  default?: any;
+  readOnly?: boolean;
+  writeOnly?: boolean;
+  examples?: any[];
+
+  // Specification extensions
+  [pattern: `x-${string}`]: any;
+}
+
+/**
+ * Content Descriptors describe content and are reusable ways of describing either parameters or results.
+ */
+export interface ContentDescriptorObject {
+  /** REQUIRED. Name of the content that is being described. */
+  name: string;
+  /** A short summary of the content that is being described. */
+  summary?: string;
+  /** A verbose explanation of the content descriptor behavior. GitHub Flavored Markdown syntax MAY be used for rich text representation. */
+  description?: string;
+  /** Determines if the content is a required field. Default value is false. */
+  required?: boolean;
+  /** REQUIRED. Schema that describes the content. */
+  schema: SchemaObject | ReferenceObject;
+  /** Specifies that the content is deprecated and SHOULD be transitioned out of usage. Default value is false. */
+  deprecated?: boolean;
+  /** Specification extensions */
+  [pattern: `x-${string}`]: any;
+}
+
+/**
+ * Parameter structure options for JSON-RPC methods
+ */
+export type ParamStructure = "by-name" | "by-position" | "either";
+
+/**
+ * Application defined error code type
+ */
+export type ApplicationDefinedErrorCode = number;
+
+/**
+ * The Example object defines an example that is intended to match the schema of a given Content Descriptor.
+ */
+export interface ExampleObject {
+  /** Canonical name of the example. */
+  name?: string;
+  /** Short description for the example. */
+  summary?: string;
+  /** A verbose explanation of the example. GitHub Flavored Markdown syntax MAY be used for rich text representation. */
+  description?: string;
+  /** Embedded literal example. The value field and externalValue field are mutually exclusive. */
+  value?: any;
+  /** A URL that points to the literal example. The value field and externalValue field are mutually exclusive. */
+  externalValue?: string;
+  /** Specification extensions */
+  [pattern: `x-${string}`]: any;
+}
+
+/**
+ * The Example Pairing object consists of a set of example params and result.
+ */
+export interface ExamplePairingObject {
+  /** REQUIRED. Name for the example pairing. */
+  name: string;
+  /** A verbose explanation of the example pairing. */
+  description?: string;
+  /** Short description for the example pairing. */
+  summary?: string;
+  /** REQUIRED. Example parameters. */
+  params: (ExampleObject | ReferenceObject)[];
+  /** Example result. When undefined, the example pairing represents usage of the method as a notification. */
+  result?: ExampleObject | ReferenceObject;
+  /** Specification extensions */
+  [pattern: `x-${string}`]: any;
+}
+
+/**
+ * The Link object represents a possible design-time link for a result.
+ */
+export interface LinkObject {
+  /** REQUIRED. Canonical name of the link. */
+  name: string;
+  /** A description of the link. GitHub Flavored Markdown syntax MAY be used for rich text representation. */
+  description?: string;
+  /** Short description for the link. */
+  summary?: string;
+  /** The name of an existing, resolvable OpenRPC method. This field MUST resolve to a unique Method Object. */
+  method?: string;
+  /** A map representing parameters to pass to a method as specified with method. */
+  params?: Record<string, any | RuntimeExpression>;
+  /** A server object to be used by the target method. */
+  server?: ServerObject;
+  /** Specification extensions */
+  [pattern: `x-${string}`]: any;
+}
+
+/**
+ * Defines an application level error.
+ */
+export interface ErrorObject {
+  /** REQUIRED. A Number that indicates the error type that occurred. This MUST be an integer. */
+  code: ApplicationDefinedErrorCode;
+  /** REQUIRED. A String providing a short description of the error. The message SHOULD be limited to a concise single sentence. */
+  message: string;
+  /** A Primitive or Structured value that contains additional information about the error. This may be omitted. */
+  data?: any;
+  /** Specification extensions */
+  [pattern: `x-${string}`]: any;
+}
+
+/**
+ * Holds a set of reusable objects for different aspects of the OpenRPC.
+ */
+export interface ComponentsObject {
+  /** An object to hold reusable Content Descriptor Objects. */
+  contentDescriptors?: Record<string, ContentDescriptorObject>;
+  /** An object to hold reusable Schema Objects. */
+  schemas?: Record<string, SchemaObject>;
+  /** An object to hold reusable Example Objects. */
+  examples?: Record<string, ExampleObject>;
+  /** An object to hold reusable Link Objects. */
+  links?: Record<string, LinkObject>;
+  /** An object to hold reusable Error Objects. */
+  errors?: Record<string, ErrorObject>;
+  /** An object to hold reusable Example Pairing Objects. */
+  examplePairingObjects?: Record<string, ExamplePairingObject>;
+  /** An object to hold reusable Tag Objects. */
+  tags?: Record<string, TagObject>;
+  /** Specification extensions */
+  [pattern: `x-${string}`]: any;
+}
+
+/**
+ * A simple object to allow referencing other components in the specification, internally and externally.
+ */
+export interface ReferenceObject {
+  /** REQUIRED. The reference string. */
+  $ref: string;
+}
+
+/**
+ * Adds metadata to a single tag that is used by the Method Object.
+ */
+export interface TagObject {
+  /** REQUIRED. The name of the tag. */
+  name: string;
+  /** A short summary of the tag. */
+  summary?: string;
+  /** A verbose explanation for the tag. GitHub Flavored Markdown syntax MAY be used for rich text representation. */
+  description?: string;
+  /** Additional external documentation for this tag. */
+  externalDocs?: ExternalDocumentationObject;
+  /** Specification extensions */
+  [pattern: `x-${string}`]: any;
+}
+
+/**
+ * Allows referencing an external resource for extended documentation.
+ */
+export interface ExternalDocumentationObject {
+  /** A verbose explanation of the target documentation. GitHub Flavored Markdown syntax MAY be used for rich text representation. */
+  description?: string;
+  /** REQUIRED. The URL for the target documentation. Value MUST be in the format of a URL. */
+  url: string;
+  /** Specification extensions */
+  [pattern: `x-${string}`]: any;
+}
+
+/**
+ * Describes the interface for the given method name.
+ */
+export interface MethodObject {
+  /** REQUIRED. The canonical name for the method. The name MUST be unique within the methods array. */
+  name: string;
+  /** A list of tags for API documentation control. Tags can be used for logical grouping of methods by resources or any other qualifier. */
+  tags?: (TagObject | ReferenceObject)[];
+  /** A short summary of what the method does. */
+  summary?: string;
+  /** A verbose explanation of the method behavior. GitHub Flavored Markdown syntax MAY be used for rich text representation. */
+  description?: string;
+  /** Additional external documentation for this method. */
+  externalDocs?: ExternalDocumentationObject;
+  /** REQUIRED. A list of parameters that are applicable for this method. */
+  params: (ContentDescriptorObject | ReferenceObject)[];
+  /** The description of the result returned by the method. If undefined, the method MUST only be used as a notification. */
+  result?: ContentDescriptorObject | ReferenceObject;
+  /** Declares this method to be deprecated. Consumers SHOULD refrain from usage of the declared method. Default value is false. */
+  deprecated?: boolean;
+  /** An alternative servers array to service this method. If an alternative servers array is specified at the Root level, it will be overridden by this value. */
+  servers?: ServerObject[];
+  /** A list of custom application defined errors that MAY be returned. The Errors MUST have unique error codes. */
+  errors?: (ErrorObject | ReferenceObject)[];
+  /** A list of possible links from this method call. */
+  links?: (LinkObject | ReferenceObject)[];
+  /** The expected format of the parameters. Defaults to "either". */
+  paramStructure?: ParamStructure;
+  /** Array of Example Pairing Objects where each example includes a valid params-to-result Content Descriptor pairing. */
+  examples?: (ExamplePairingObject | ReferenceObject)[];
+  /** Specification extensions */
+  [pattern: `x-${string}`]: any;
+}
+
+/**
+ * This is the root object of the OpenRPC document.
+ */
+export interface OpenRPCDocument {
+  /** REQUIRED. This string MUST be the semantic version number of the OpenRPC Specification version that the OpenRPC document uses. */
+  openrpc: `1.3.2`;
+  /** REQUIRED. Provides metadata about the API. The metadata MAY be used by tooling as required. */
+  info: InfoObject;
+  /** An array of Server Objects, which provide connectivity information to a target server. */
+  servers?: ServerObject[];
+  /** REQUIRED. The available methods for the API. While it is required, the array may be empty. */
+  methods: (MethodObject | ReferenceObject)[];
+  /** An element to hold various schemas for the specification. */
+  components?: ComponentsObject;
+  /** Additional external documentation. */
+  externalDocs?: ExternalDocumentationObject;
+  /** Specification extensions */
+  [pattern: `x-${string}`]: any;
+}
+
+// Utility types for common patterns
+
+/**
+ * Union type for objects that can be either the actual object or a reference
+ */
+export type Referenceable<T> = T | ReferenceObject;
+
+/**
+ * Type guard to check if an object is a ReferenceObject
+ */
+export function isReferenceObject(obj: any): obj is ReferenceObject {
+  return obj && typeof obj === "object" && typeof obj.$ref === "string";
+}
+
+/**
+ * Type guard to check if an object is a valid OpenRPC document
+ */
+export function isOpenRPCDocument(obj: any): obj is OpenRPCDocument {
+  return (
+    obj &&
+    typeof obj === "object" &&
+    typeof obj.openrpc === "string" &&
+    obj.info &&
+    typeof obj.info === "object" &&
+    typeof obj.info.title === "string" &&
+    typeof obj.info.version === "string" &&
+    Array.isArray(obj.methods)
+  );
+}
+
+export type OpenRPCVersion = `1.0.${number}`;
+
+/**
+ * Service discovery method name as defined in the OpenRPC specification
+ */
+export const SERVICE_DISCOVERY_METHOD = "rpc.discover" as const;
+
+export const fromJsonRpcRouter = (jsonRpcRouter: JsonRpcRouter) => {
+  const document: OpenRPCDocument = {
+    openrpc: "1.3.2",
+    info: {
+      title: jsonRpcRouter.options.info?.title ?? "JSON-RPC Service",
+      version: jsonRpcRouter.options.info?.version ?? "1.0.0",
+      description:
+        jsonRpcRouter.options.info?.description ??
+        "A JSON-RPC service for various operations",
+    },
+    methods: [],
+  };
+
+  for (const { method, params, result } of JsonRpcRouter.getMethods(
+    jsonRpcRouter,
+  )) {
+    const paramsO: (ContentDescriptorObject | ReferenceObject)[] = [];
+    let resulO: undefined | ContentDescriptorObject | ReferenceObject =
+      undefined;
+
+    if (params?.def.type === "object") {
+      for (const [key, schema] of Object.entries(params.def.shape)) {
+        paramsO.push({
+          name: key,
+          schema: toJSONSchema(schema as any) as SchemaObject,
+        });
+      }
+    }
+
+    if (params?.def.type === "tuple") {
+      let n = 0;
+      for (const t of params.def.items) {
+        paramsO.push({
+          name: `item${n++}`,
+          schema: toJSONSchema(t as any) as SchemaObject,
+        });
+      }
+    }
+
+    if (result) {
+      resulO = {
+        name: "result",
+        schema: toJSONSchema(result) as SchemaObject,
+      };
+    }
+
+    document.methods.push({
+      name: method,
+      params: paramsO,
+      result: resulO,
+    });
+  }
+
+  return document;
+};


### PR DESCRIPTION
## 🚀 Features

### OpenRPC Document Generation
- **New utility**: `fromJsonRpcRouter()` function that generates OpenRPC 1.3.2 compliant documents
- **Service discovery**: Automatic generation of method documentation with parameter and result schemas
- **Enhanced method listing**: Simplified `registerListMethods()` implementation using the new OpenRPC generator
- **Schema support**: Full support for both object and tuple parameter structures with Zod validation

### Enhanced Type System
- **Refined validation types**: Introduced `ParamsValidation<T>` type for better parameter type inference
- **Improved Zod integration**: Enhanced `ParamsZodValidation` to properly handle objects and tuples
- **Type safety**: Better distinction between parameter validation and general validation types

### Router Improvements
- **Refactored architecture**: Renamed `JsonRpcDispatcherOptions` to `JsonRpcRouterOptions` for clarity
- **Enhanced options**: Added optional `info` field for OpenRPC document metadata (title, version, description)
- **Method introspection**: New static `getMethods()` iterator for accessing registered methods with their validations
- **Improved documentation**: Updated terminology from "dispatcher" to "router" throughout codebase

## 🧪 Testing

- ✅ All existing tests pass
- ✅ New comprehensive test suite for OpenRPC document generation
- ✅ Snapshot testing for generated OpenRPC documents
- ✅ Support for both object and tuple parameter validation
- ✅ Schema description preservation in generated documents

## 📚 Documentation

The new OpenRPC document generation allows for automatic API documentation and discovery:

```typescript
const router = new JsonRpcRouter();

router.method("sum", (params) => params.a + params.b, {
  inputValidation: z.object({
    a: z.number(),
    b: z.number(),
  }),
  outputValidation: z.number(),
});

// Generate OpenRPC document
const openRpcDoc = fromJsonRpcRouter(router);
```

## 🔧 Breaking Changes

- Type signature change for method parameter validation (now uses `ParamsValidation<T>`)
- Renamed `JsonRpcDispatcherOptions` to `JsonRpcRouterOptions`
- Updated internal validation type handling

## 🏗️ Architecture

- Maintains backward compatibility for existing JSON-RPC functionality
- Enhanced type inference for better developer experience  
- Modular design allows for easy extension of OpenRPC features