### PR TITLE
refactor(json-rpc): rename inputValidation to paramsValidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1005,7 +1005,6 @@ rpc.method(
 When registering methods with `method()`, you can provide these options:
 
 - **`inputValidation`** (optional): Zod schema to validate input parameters
-
   - Automatically validates parameters before calling the handler
   - Returns JSON-RPC error (-32602 Invalid params) if validation fails
   - Provides automatic TypeScript typing for the params argument

--- a/src/json-rpc/json-rpc-router.spec.ts
+++ b/src/json-rpc/json-rpc-router.spec.ts
@@ -252,7 +252,7 @@ describe("JsonRpcRouter", () => {
         expectTypeOf(params).toEqualTypeOf<{ name: string }>();
       },
       {
-        inputValidation: input,
+        paramsValidation: input,
       },
     );
   });
@@ -280,7 +280,7 @@ describe("JsonRpcRouter", () => {
         };
       },
       {
-        inputValidation: input,
+        paramsValidation: input,
         outputValidation: output,
       },
     );
@@ -327,7 +327,7 @@ describe("JsonRpcRouter", () => {
     });
 
     dispatcher.method("testMethod", handler, {
-      inputValidation: input,
+      paramsValidation: input,
     });
 
     expect(async () => {
@@ -353,7 +353,7 @@ describe("JsonRpcRouter", () => {
     });
 
     dispatcher.method("testMethod", handler, {
-      inputValidation: input,
+      paramsValidation: input,
     });
 
     const response = await dispatcher.request({
@@ -383,7 +383,7 @@ describe("JsonRpcRouter", () => {
     });
 
     dispatcher.method("testMethod", handler, {
-      inputValidation: input,
+      paramsValidation: input,
     });
 
     const response = await dispatcher.request({
@@ -442,7 +442,7 @@ describe("JsonRpcRouter", () => {
     const dispatcher = new JsonRpcRouter();
 
     dispatcher.method("testMethod", mock(), {
-      inputValidation: z.object({ name: z.string() }),
+      paramsValidation: z.object({ name: z.string() }),
     });
 
     dispatcher.enableMethodListing("rpc.discover");
@@ -452,7 +452,7 @@ describe("JsonRpcRouter", () => {
     const dispatcher = new JsonRpcRouter();
 
     dispatcher.method("testMethod", mock(), {
-      inputValidation: z.object({ name: z.string() }),
+      paramsValidation: z.object({ name: z.string() }),
     });
 
     dispatcher.enableMethodListing("rpc.discover");
@@ -478,7 +478,7 @@ describe("JsonRpcRouter", () => {
     const dispatcher = new JsonRpcRouter();
 
     dispatcher.method("testMethod", mock(), {
-      inputValidation: z.object({ name: z.string() }),
+      paramsValidation: z.object({ name: z.string() }),
       outputValidation: z.object({ ok: z.boolean() }),
     });
 

--- a/src/json-rpc/json-rpc-router.ts
+++ b/src/json-rpc/json-rpc-router.ts
@@ -225,6 +225,8 @@ export class JsonRpcRouter {
       ExtractValidationType<OutputValidation>
     >,
     options?: {
+      paramsValidation?: InputValidation;
+      /** @deprecated Use `paramsValidation` instead. This option will be removed in a future version. */
       inputValidation?: InputValidation;
       outputValidation?: OutputValidation;
       middlewares?: JsonRpcMiddleware[];
@@ -234,10 +236,13 @@ export class JsonRpcRouter {
     if (options?.middlewares) {
       this.methodsMiddlewares.set(method, options.middlewares);
     }
-    if (options?.inputValidation || options?.outputValidation) {
+    const paramsValidation =
+      options?.paramsValidation ?? options?.inputValidation;
+    const outputValidation = options?.outputValidation;
+    if (paramsValidation || outputValidation) {
       this.paramsValidations.set(method, {
-        input: options.inputValidation,
-        output: options.outputValidation,
+        input: paramsValidation,
+        output: outputValidation,
       });
     }
   }
@@ -419,12 +424,12 @@ export class JsonRpcRouter {
       .catch((error) => {
         if (JsonRpcError.isJsonRpcError(error)) {
           return error.toJsonRpcResponse(
-            "id" in request ? request.id ?? null : null,
+            "id" in request ? (request.id ?? null) : null,
           );
         }
         console.error("Internal error processing request:", error);
         return new JsonRpcError(-32603, "Internal error").toJsonRpcResponse(
-          "id" in request ? request.id ?? null : null,
+          "id" in request ? (request.id ?? null) : null,
         );
       })
       .finally(() => {

--- a/src/json-rpc/utils/open-rpc-document.spec.ts
+++ b/src/json-rpc/utils/open-rpc-document.spec.ts
@@ -8,7 +8,7 @@ describe("open-rpc-document", () => {
     const router = new JsonRpcRouter();
 
     router.method("sum", (params) => params.a + params.b, {
-      inputValidation: z.object({
+      paramsValidation: z.object({
         a: z.number(),
         b: z.number(),
       }),
@@ -22,7 +22,7 @@ describe("open-rpc-document", () => {
     const router = new JsonRpcRouter();
 
     router.method("sum", ([a, b]) => a + b, {
-      inputValidation: z.tuple([z.number(), z.number()]),
+      paramsValidation: z.tuple([z.number(), z.number()]),
       outputValidation: z.number(),
     });
 
@@ -33,7 +33,7 @@ describe("open-rpc-document", () => {
     const router = new JsonRpcRouter();
 
     router.method("sum", ([a, b]) => ({ result: a + b }), {
-      inputValidation: z.tuple([z.number(), z.number()]),
+      paramsValidation: z.tuple([z.number(), z.number()]),
       outputValidation: z.object({
         result: z.number(),
       }),
@@ -46,7 +46,7 @@ describe("open-rpc-document", () => {
     const router = new JsonRpcRouter();
 
     router.method("sum", ([a, b]) => ({ result: a + b }), {
-      inputValidation: z.tuple([
+      paramsValidation: z.tuple([
         z.number().describe("The first number"),
         z.number().describe("The second number"),
       ]),


### PR DESCRIPTION
- Rename `inputValidation` option to `paramsValidation` across router method configuration
- Mark `inputValidation` as deprecated with migration notice for future removal
- Update all test cases to use new `paramsValidation` naming convention
- Update OpenRPC document generation tests to reflect new parameter naming
- Add parentheses around ternary expressions for improved code clarity
- Improves semantic accuracy by clarifying that validation applies to method parameters